### PR TITLE
redirect insecure connections to HTTPS

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,14 +10,16 @@ const PORT = process.env.PORT || 8443;
 // };
 
 function forceHTTPS(req, res, next) {
-  const isSecure = req.isSecure || (req.headers["x-forwarded-proto"] || '').substring(0,5) === 'https';
+  const isSecure =
+    req.isSecure ||
+    (req.headers["x-forwarded-proto"] || "").substring(0, 5) === "https";
 
-  if(isSecure) {
+  if (isSecure) {
     next();
     return;
   }
 
-  if(req.method === "GET" || req.method === 'HEAD') {
+  if (req.method === "GET" || req.method === "HEAD") {
     res.redirect(301, "https://" + req.headers.host + req.originalUrl);
   } else {
     res.status(403).send("Server requires HTTPS.");

--- a/server.js
+++ b/server.js
@@ -13,7 +13,7 @@ function forceHTTPS(req, res, next) {
   const isSecure =
     req.secure ||
     // If behind a proxy, check for the X-Forwarded-Proto header.
-    (req.headers["x-forwarded-proto"] || "").substring(0, 5) === "https";
+    req.headers["x-forwarded-proto"] === "https";
 
   if (isSecure) {
     next();

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ const PORT = process.env.PORT || 8443;
 function forceHTTPS(req, res, next) {
   const isSecure =
     req.secure ||
+    // If behind a proxy, check for the X-Forwarded-Proto header.
     (req.headers["x-forwarded-proto"] || "").substring(0, 5) === "https";
 
   if (isSecure) {

--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ const PORT = process.env.PORT || 8443;
 
 function forceHTTPS(req, res, next) {
   const isSecure =
-    req.isSecure ||
+    req.secure ||
     (req.headers["x-forwarded-proto"] || "").substring(0, 5) === "https";
 
   if (isSecure) {

--- a/server.js
+++ b/server.js
@@ -9,7 +9,23 @@ const PORT = process.env.PORT || 8443;
 //   cert: fs.readFileSync("server.pem"),
 // };
 
+function forceHTTPS(req, res, next) {
+  const isSecure = req.isSecure || (req.headers["x-forwarded-proto"] || '').substring(0,5) === 'https';
+
+  if(isSecure) {
+    next();
+    return;
+  }
+
+  if(req.method === "GET" || req.method === 'HEAD') {
+    res.redirect(301, "https://" + req.headers.host + req.originalUrl);
+  } else {
+    res.status(403).send("Server requires HTTPS.");
+  }
+}
+
 const app = express();
+app.use(forceHTTPS);
 app.use(express.static("public"));
 
 const httpServer = http.createServer(app);


### PR DESCRIPTION
iOS requires a secure connection to make the media devices API available. 

If the client application is accessed over `http` `navigator.mediaDevices` will be `undefined`. 

Checking the Heroku documentation, it seems up to the client application to handle the redirection (we can't fiddle with the nginx configuration or whatever reverse-proxy they use behind the scene) but fortunately, their proxy still set a `x-forwarded-proto` header we can use to know whether the original request was secure or not.